### PR TITLE
[FS-219619] Fix Deprecation warnings in record_not_unique for ruby 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'activerecord', ENV.fetch('ACTIVE_RECORD_VERSION', '>= 5.2')
+gem 'activerecord', ENV.fetch('ACTIVE_RECORD_VERSION', '>= 6.1')
 
 gem 'mysql2'
 gem 'rspec'

--- a/lib/record_not_unique.rb
+++ b/lib/record_not_unique.rb
@@ -62,8 +62,7 @@ module RecordNotUnique
         error_object = custom_error.last
         error_object = error_object.call if error_object.is_a?(Proc)
 
-        error_object = { message: error_object } unless error_object.is_a?(Hash)
-        errors.add(custom_error.first, **error_object)
+        error_object.is_a?(Hash) ? errors.add(custom_error.first, **error_object) : errors.add(custom_error.first, error_object)
       end
       false
     end

--- a/lib/record_not_unique.rb
+++ b/lib/record_not_unique.rb
@@ -67,10 +67,11 @@ module RecordNotUnique
         next unless e.message.include?(index_name)
 
         custom_error = self.class._rnu_error_messages[i]
-        object = custom_error.last
-        custom_error_msg = object.is_a?(Proc) ? object.call(self) : object
+        error_object = custom_error.last
+        error_object = error_object.call if error_object.is_a?(Proc)
 
-        errors.add(custom_error.first, custom_error_msg)
+        error_object = { message: error_object } unless error_object.is_a?(Hash)
+        errors.add(custom_error.first, **error_object)
       end
       false
     end

--- a/lib/record_not_unique.rb
+++ b/lib/record_not_unique.rb
@@ -43,17 +43,9 @@ module RecordNotUnique
       end
     end
 
-    if ActiveRecord::VERSION::MAJOR >= 6
-      def save(**options, &block)
-        handle_custom_unique_constraint do
-          super
-        end
-      end
-    else
-      def save(*args, &block)
-        handle_custom_unique_constraint do
-          super
-        end
+    def save(**options, &block)
+      handle_custom_unique_constraint do
+        super
       end
     end
 

--- a/lib/record_not_unique/version.rb
+++ b/lib/record_not_unique/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RecordNotUnique
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end

--- a/lib/record_not_unique/version.rb
+++ b/lib/record_not_unique/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RecordNotUnique
-  VERSION = '2.2.1'
+  VERSION = '2.2.0'
 end

--- a/record_not_unique.gemspec
+++ b/record_not_unique.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
   s.homepage      = 'http://rubygems.org/gems/record_not_unique'
   s.license       = 'MIT'
   s.required_ruby_version = '>= 2.5.0'
-  s.add_runtime_dependency 'activerecord', '>= 6.1'
   s.add_runtime_dependency 'activemodel', '>= 6.1'
+  s.add_runtime_dependency 'activerecord', '>= 6.1'
 
   s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/record_not_unique.gemspec
+++ b/record_not_unique.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |s|
   s.homepage      = 'http://rubygems.org/gems/record_not_unique'
   s.license       = 'MIT'
   s.required_ruby_version = '>= 2.5.0'
-  s.add_runtime_dependency 'activerecord', '>= 5.2'
+  s.add_runtime_dependency 'activerecord', '>= 6.1'
+  s.add_runtime_dependency 'activemodel', '>= 6.1'
 
   s.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
As part of the upgrade from Ruby 2.6 to 2.7, we encountered the following deprecation warning:

`Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`
This warning arises due to changes in Ruby's handling of keyword arguments, which now requires explicit usage of the ** syntax to correctly pass keyword arguments.

To address this, I have updated the affected method calls to conform to Ruby 2.7's requirements by adding the ** syntax where applicable. Additionally, we can also use the `ruby2_keywords` method in specific scenarios to maintain compatibility without requiring extensive refactoring.

These changes ensure compatibility with Ruby 2.7, avoid runtime issues, and prepare the application for future upgrades.


Rails 6.1 Changelog: https://github.com/rails/rails/blob/6-1-stable/activemodel/CHANGELOG.md#rails-610-december-09-2020